### PR TITLE
fix: Correct API URLs in Swagger docs

### DIFF
--- a/ctenex/api/main.py
+++ b/ctenex/api/main.py
@@ -13,7 +13,7 @@ settings = get_app_settings()
 
 host = settings.api.api_host
 port = settings.api.api_port
-base_url = settings.api.base_url
+base_url = str(settings.api.base_url)
 
 app = create_app(routers=[])
 

--- a/ctenex/api/main.py
+++ b/ctenex/api/main.py
@@ -13,6 +13,7 @@ settings = get_app_settings()
 
 host = settings.api.api_host
 port = settings.api.api_port
+base_url = settings.api.base_url
 
 app = create_app(routers=[])
 
@@ -21,14 +22,14 @@ stateful_app = create_app(
     lifespan=lifespan,
     routers=[status_router, stateful_exchange_router],
 )
-stateful_app_url = f"http://{host}:{port}{stateful_app_path}"
+stateful_app_url = f"{base_url}{stateful_app_path}"
 app.mount(stateful_app_path, stateful_app)
 
 stateless_app_path = "/v1/stateless/"
 stateless_app = create_app(
     routers=[status_router, stateless_exchange_router],
 )
-stateless_app_url = f"http://{host}:{port}{stateless_app_path}"
+stateless_app_url = f"{base_url}{stateless_app_path}"
 app.mount(stateless_app_path, stateless_app)
 
 

--- a/ctenex/settings/api.py
+++ b/ctenex/settings/api.py
@@ -1,4 +1,4 @@
-from pydantic import Field, IPvAnyAddress
+from pydantic import Field, IPvAnyAddress, HttpUrl
 
 from ctenex.settings.base import CommonSettings
 
@@ -8,4 +8,8 @@ class APISettings(CommonSettings):
         validation_alias="API_HOST",
         default=IPvAnyAddress("0.0.0.0"),  # type: ignore
     )
-    api_port: int = Field(validation_alias="API_PORT", default=3000)
+    api_port: int = Field(validation_alias="API_PORT", default=8000)
+    base_url: HttpUrl = Field(
+        validation_alias="BASE_URL",
+        default="http://localhost:8000",
+    )

--- a/ctenex/settings/api.py
+++ b/ctenex/settings/api.py
@@ -1,4 +1,4 @@
-from pydantic import Field, IPvAnyAddress, HttpUrl
+from pydantic import Field, HttpUrl, IPvAnyAddress
 
 from ctenex.settings.base import CommonSettings
 
@@ -11,5 +11,5 @@ class APISettings(CommonSettings):
     api_port: int = Field(validation_alias="API_PORT", default=8000)
     base_url: HttpUrl = Field(
         validation_alias="BASE_URL",
-        default="http://localhost:8000",
+        default=HttpUrl("http://localhost:8000"),
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ctenex"
-version = "0.1.0"
+version = "0.1.1"
 description = ""
 authors = [
     {name = "Your Name",email = "you@example.com"}


### PR DESCRIPTION
## 📝 Description

Changes in this MR add a new API setting (`base_url`) to allow setting up dynamic links in the Swagger docs depending on the domain the app is serving on.

### 💼 Type of change

- [X] Fix

### 📋 Related ticket(s)

- Closes #18

### 📌 Additional comments

NOTE: This changes require a new `BASE_URL` environment variable in Render.
