### PR TITLE
feat: Add timestamp filtering for GET /orders

### DIFF
--- a/ctenex/api/middlewares/filter_sort.py
+++ b/ctenex/api/middlewares/filter_sort.py
@@ -1,0 +1,28 @@
+from typing import Callable, Type, TypeAlias, get_args
+
+from fastapi import Query
+
+from ctenex.core.utils.filter_sort import SortOptions, SortOrder, SortParams
+
+
+def parse_sorting(options: Type[SortOptions]) -> Callable:
+    OptionsAlias: TypeAlias = options  # type: ignore[valid-type]
+
+    async def _parse_sort(
+        sort_by: OptionsAlias | None = Query(
+            default=None,
+            examples=None,
+            description=f"A key to sort by. Options: {', '.join(options)}",
+        ),
+        sort_order: SortOrder | None = Query(
+            default=None,
+            description=f"Options: {', '.join(list(get_args(SortOrder)))}",
+        ),
+    ):
+        if sort_by and sort_order:
+            return SortParams(
+                sort_by=sort_by,
+                sort_order=sort_order,
+            )
+
+    return _parse_sort

--- a/ctenex/api/v1/controllers/exchange.py
+++ b/ctenex/api/v1/controllers/exchange.py
@@ -2,12 +2,15 @@ from typing import Annotated
 
 from fastapi import APIRouter, Body, Depends
 
+from ctenex.api.middlewares.filter_sort import parse_sorting
 from ctenex.core.db.async_session import AsyncSessionStream, db
 from ctenex.core.db.utils import get_entity_values
+from ctenex.core.utils.filter_sort import SortParams
 from ctenex.domain.entities import OpenOrderStatus
 from ctenex.domain.matching_engine.model import matching_engine
 from ctenex.domain.order_book.contract.reader import contracts_reader
 from ctenex.domain.order_book.contract.schemas import ContractGetResponse
+from ctenex.domain.order_book.model import OrderSortOptions
 from ctenex.domain.order_book.order.model import Order
 from ctenex.domain.order_book.order.reader import OrderFilter
 from ctenex.domain.order_book.order.schemas import (
@@ -36,6 +39,7 @@ async def place_order(
 @router.get("/orders")
 async def get_orders(
     filter: Annotated[OrderFilter, Depends()],
+    sort: Annotated[SortParams, Depends(parse_sorting(OrderSortOptions))],
     limit: int = 10,
     page: int = 1,
 ) -> list[OrderGetResponse]:
@@ -43,6 +47,7 @@ async def get_orders(
         filter=filter,
         page=page,
         limit=limit,
+        sort=sort,
     )
     return [OrderGetResponse(**order.model_dump(exclude_none=True)) for order in orders]
 

--- a/ctenex/core/db/base.py
+++ b/ctenex/core/db/base.py
@@ -1,8 +1,9 @@
 import uuid
-from datetime import UTC, datetime
+from datetime import datetime
 
+from sqlalchemy import func
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
-from sqlalchemy.types import TIMESTAMP, UUID, Boolean
+from sqlalchemy.types import TIMESTAMP, UUID, Boolean, DateTime
 
 
 class Base(DeclarativeBase):
@@ -19,14 +20,14 @@ class AbstractBase(Base):
         nullable=False,
     )
     created_at: Mapped[datetime] = mapped_column(
-        type_=TIMESTAMP(timezone=True),
-        default=datetime.now(UTC),
+        # type_=TIMESTAMP(timezone=True),
+        type_=DateTime(timezone=True),
+        server_default=func.now(),
         nullable=False,
     )
     updated_at: Mapped[datetime] = mapped_column(
-        type_=TIMESTAMP(timezone=True),
-        default=datetime.now(UTC),
-        onupdate=datetime.now(UTC),
+        type_=DateTime(timezone=True),
+        server_default=func.now(),
         nullable=False,
     )
     deleted_at: Mapped[datetime] = mapped_column(

--- a/ctenex/core/db/utils.py
+++ b/ctenex/core/db/utils.py
@@ -5,5 +5,9 @@ from sqlalchemy.inspection import inspect
 from ctenex.core.db.base import AbstractBase
 
 
-def get_entity_values(entity: Type[AbstractBase]) -> dict:
+def get_entity_values(entity: AbstractBase) -> dict:
     return {c.key: getattr(entity, c.key) for c in inspect(entity).mapper.column_attrs}
+
+
+def get_entity_fields(entity: Type[AbstractBase]) -> list[str]:
+    return [c.key for c in inspect(entity).mapper.column_attrs]

--- a/ctenex/core/db/utils.py
+++ b/ctenex/core/db/utils.py
@@ -1,7 +1,8 @@
+from typing import Type
 from sqlalchemy.inspection import inspect
 
 from ctenex.core.db.base import AbstractBase
 
 
-def get_entity_values(entity: AbstractBase) -> dict:
+def get_entity_values(entity: Type[AbstractBase]) -> dict:
     return {c.key: getattr(entity, c.key) for c in inspect(entity).mapper.column_attrs}

--- a/ctenex/core/db/utils.py
+++ b/ctenex/core/db/utils.py
@@ -1,4 +1,5 @@
 from typing import Type
+
 from sqlalchemy.inspection import inspect
 
 from ctenex.core.db.base import AbstractBase

--- a/ctenex/core/utils/filter_sort.py
+++ b/ctenex/core/utils/filter_sort.py
@@ -1,11 +1,22 @@
+from datetime import datetime
 from enum import Enum
-from typing import Literal
+from typing import Literal, Type
 
 from pydantic import BaseModel
+from sqlalchemy import Select, column
+
+from ctenex.core.db.base import AbstractBase
+from ctenex.core.db.utils import get_entity_values
 
 # Filtering
 
-FilterType = str | int | bool
+# Timestamp-related filtering constants
+TIMESTAMP_FIELD_SUFFIX = "_at"
+TIMESTAMP_AT_OR_AFTER_FILTER_SUFFIX = "_at_or_after"
+TIMESTAMP_BEFORE_FILTER_SUFFIX = "_before"
+
+
+FilterType = str | int | bool | datetime
 
 
 class BaseFilterParams(BaseModel):
@@ -14,10 +25,90 @@ class BaseFilterParams(BaseModel):
     used in the query).
 
     When subclassing, define the filter parameters as fields.
+
+    Note: datetime filters are only supported for datetime fields.
+
+    When using datetime filters, the field name must end with `_or_after` and
+    the name of the actual column must end with `_at`.
+    The value must be a datetime object.
+
+    Example for a model with a `placed_at` field:
+    ```
+    class OrderFilterParams(BaseFilterParams):
+        contract_id: str | None = None
+        placed_at_between: datetime | None = None
+    ```
     """
 
-    def get_filters(self) -> dict[str, FilterType]:
+    @property
+    def total_number_of_filters(self) -> int:
+        return len(self._get_filters())
+
+    def _get_filters(self) -> dict[str, FilterType]:
         return self.model_dump(exclude_none=True, exclude_unset=True)
+
+    def apply_to_statement(self, statement: Select, model: Type[AbstractBase]) -> Select:
+        filters = self._get_filters()
+
+        table_column_names = list(get_entity_values(model))
+
+        # Get timestamp keys
+        timestamp_column_names = [
+            column_name
+            for column_name in table_column_names
+            if column_name.endswith(TIMESTAMP_FIELD_SUFFIX)
+        ]
+
+        timestamp_filters = {
+            key: value
+            for key, value in filters.items()
+            if key.endswith(TIMESTAMP_AT_OR_AFTER_FILTER_SUFFIX)
+            or key.endswith(TIMESTAMP_BEFORE_FILTER_SUFFIX)
+        }
+
+        # Check if any timestamp filter is valid (exists in table_column_names
+        timestamp_column_names_from_valid_filters = {}
+
+        for key in timestamp_filters.keys():
+            if key.endswith(TIMESTAMP_AT_OR_AFTER_FILTER_SUFFIX):
+                potentially_valid_timestamp_column_name = (
+                    (key.split(TIMESTAMP_AT_OR_AFTER_FILTER_SUFFIX)[0])
+                    + TIMESTAMP_FIELD_SUFFIX
+                )
+                if potentially_valid_timestamp_column_name in timestamp_column_names:
+                    timestamp_column_names_from_valid_filters[key] = (
+                        potentially_valid_timestamp_column_name
+                    )
+            elif key.endswith(TIMESTAMP_BEFORE_FILTER_SUFFIX):
+                potentially_valid_timestamp_column_name = (
+                    (key.split(TIMESTAMP_BEFORE_FILTER_SUFFIX)[0])
+                    + TIMESTAMP_FIELD_SUFFIX
+                )
+                if potentially_valid_timestamp_column_name in timestamp_column_names:
+                    timestamp_column_names_from_valid_filters[key] = (
+                        potentially_valid_timestamp_column_name
+                    )
+
+        if len(timestamp_column_names_from_valid_filters) != len(timestamp_filters):
+            raise ValueError(f"Invalid timestamp filters: {timestamp_filters}")
+
+        # Apply filters
+        for key, value in filters.items():
+            if key.endswith(TIMESTAMP_BEFORE_FILTER_SUFFIX) and isinstance(
+                value, datetime
+            ):
+                statement = statement.where(
+                    column(timestamp_column_names_from_valid_filters[key]) < value
+                )
+            elif key.endswith(TIMESTAMP_AT_OR_AFTER_FILTER_SUFFIX) and isinstance(
+                value, datetime
+            ):
+                statement = statement.where(
+                    column(timestamp_column_names_from_valid_filters[key]) >= value
+                )
+            else:
+                statement = statement.where(column(key) == value)
+        return statement
 
 
 # Sorting

--- a/ctenex/core/utils/filter_sort.py
+++ b/ctenex/core/utils/filter_sort.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from sqlalchemy import Select, column
 
 from ctenex.core.db.base import AbstractBase
-from ctenex.core.db.utils import get_entity_values
+from ctenex.core.db.utils import get_entity_fields
 
 # Filtering
 
@@ -54,7 +54,7 @@ class BaseFilterParams(BaseModel):
     ) -> Select:
         filters = self._get_filters()
 
-        table_column_names = list(get_entity_values(model))
+        table_column_names = get_entity_fields(model)
 
         # Get timestamp keys
         timestamp_column_names = [

--- a/ctenex/core/utils/filter_sort.py
+++ b/ctenex/core/utils/filter_sort.py
@@ -47,7 +47,11 @@ class BaseFilterParams(BaseModel):
     def _get_filters(self) -> dict[str, FilterType]:
         return self.model_dump(exclude_none=True, exclude_unset=True)
 
-    def apply_to_statement(self, statement: Select, model: Type[AbstractBase]) -> Select:
+    def apply_to_statement(
+        self,
+        statement: Select,
+        model: Type[AbstractBase],
+    ) -> Select:
         filters = self._get_filters()
 
         table_column_names = list(get_entity_values(model))

--- a/ctenex/domain/base_model.py
+++ b/ctenex/domain/base_model.py
@@ -6,8 +6,8 @@ from pydantic import BaseModel, Field
 
 class BaseDomainModel(BaseModel):
     id: UUID = Field(default_factory=uuid4)
-    created_at: datetime = Field(default=datetime.now(UTC))
-    updated_at: datetime = Field(default=datetime.now(UTC))
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     deleted_at: datetime | None = Field(default=None)
     is_deleted: bool = Field(default=False)
     is_active: bool = Field(default=True)

--- a/ctenex/domain/entities.py
+++ b/ctenex/domain/entities.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from datetime import datetime
 from decimal import Decimal
 from enum import Enum
 
+from sqlalchemy import func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.schema import ForeignKey
-from sqlalchemy.types import DECIMAL, TIMESTAMP, UUID, String
+from sqlalchemy.types import DECIMAL, UUID, DateTime, String
 
 from ctenex.core.db.base import AbstractBase
 
@@ -86,9 +87,9 @@ class BaseOrder(AbstractBase):
         nullable=False,
     )
     placed_at: Mapped[datetime] = mapped_column(
-        type_=TIMESTAMP(timezone=True),
-        default=datetime.now(UTC),
         nullable=False,
+        type_=DateTime(timezone=True),
+        server_default=func.now(),
         index=True,
     )
 
@@ -110,11 +111,9 @@ class Contract(AbstractBase):
         nullable=False,
     )
     start_date: Mapped[datetime] = mapped_column(
-        type_=TIMESTAMP(timezone=True),
         nullable=False,
     )
     end_date: Mapped[datetime] = mapped_column(
-        type_=TIMESTAMP(timezone=True),
         nullable=False,
     )
     tick_size: Mapped[Decimal] = mapped_column(
@@ -182,8 +181,8 @@ class BaseTrade(AbstractBase):
         nullable=False,
     )
     generated_at: Mapped[datetime] = mapped_column(
-        type_=TIMESTAMP(timezone=True),
-        default=datetime.now(UTC),
+        type_=DateTime(timezone=True),
+        default=func.now,
         nullable=False,
     )
 
@@ -206,9 +205,9 @@ class ProcessedOrder(BaseOrder):
     __abstract__ = True
 
     filled_at: Mapped[datetime] = mapped_column(
-        type_=TIMESTAMP(timezone=True),
-        default=datetime.now(UTC),
+        type_=DateTime(timezone=True),
         nullable=False,
+        server_default=func.now(),
         index=True,
     )
     status: Mapped[OrderStatus] = mapped_column(

--- a/ctenex/domain/matching_engine/model.py
+++ b/ctenex/domain/matching_engine/model.py
@@ -6,6 +6,7 @@ from sqlalchemy import select
 
 from ctenex.core.db.async_session import AsyncSessionStream, get_async_session
 from ctenex.core.db.utils import get_entity_values
+from ctenex.core.utils.filter_sort import SortParams
 from ctenex.domain.contracts import ContractCode
 from ctenex.domain.entities import (
     OpenOrderStatus,
@@ -65,11 +66,13 @@ class MatchingEngine:
         filter: OrderFilter,
         limit: int = 10,
         page: int = 1,
+        sort: SortParams | None = None,
     ) -> list[OrderSchema]:
         return await self.order_book.get_orders(
             filter=filter,
             limit=limit,
             page=page,
+            sort=sort,
         )
 
     async def get_order(

--- a/ctenex/domain/order_book/model.py
+++ b/ctenex/domain/order_book/model.py
@@ -5,11 +5,16 @@ from sqlalchemy import func, select
 
 from ctenex.core.db.async_session import AsyncSessionStream, get_async_session
 from ctenex.core.db.utils import get_entity_values
+from ctenex.core.utils.filter_sort import SortOptions, SortParams
 from ctenex.domain.contracts import ContractCode
 from ctenex.domain.entities import Order, OrderSide, OrderType, ProcessedOrderStatus
 from ctenex.domain.order_book.order.model import Order as OrderSchema
 from ctenex.domain.order_book.order.reader import OrderFilter, orders_reader
 from ctenex.domain.order_book.order.writer import orders_writer
+
+
+class OrderSortOptions(SortOptions):
+    placed_at = "placed_at"
 
 
 class OrderBook:
@@ -27,12 +32,14 @@ class OrderBook:
         filter: OrderFilter,
         limit: int = 10,
         page: int = 1,
+        sort: SortParams | None = None,
     ) -> list[OrderSchema]:
         orders = await self.orders_reader.get_many(
             self.db,
             filter=filter,
             limit=limit,
             page=page,
+            sort=sort,
         )
         return [OrderSchema(**get_entity_values(order)) for order in orders]
 

--- a/ctenex/domain/order_book/order/filter_params.py
+++ b/ctenex/domain/order_book/order/filter_params.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from decimal import Decimal
 
 from pydantic import field_validator
@@ -17,6 +18,16 @@ class OrderFilterParams(BaseFilterParams):
     status: OrderStatus | None = None
     price: Decimal | None = None
     quantity: Decimal | None = None
+    placed_at_or_after: datetime | None = None
+    placed_before: datetime | None = None
+
+    @field_validator("placed_before")
+    def validate_placed_before(cls, v, values):
+        placed_at_or_after = values.data.get("placed_at_or_after")
+
+        if placed_at_or_after and v and placed_at_or_after >= v:
+            raise ValueError("Placed before must be after placed at or after")
+        return v
 
     @field_validator("status", "side", "type")
     def validate_enum(cls, v):

--- a/ctenex/domain/order_book/order/model.py
+++ b/ctenex/domain/order_book/order/model.py
@@ -25,4 +25,4 @@ class Order(BaseDomainModel):
     quantity: Decimal
     status: OrderStatus = Field(default=OpenOrderStatus.OPEN)
     remaining_quantity: Decimal | None = Field(default=None)
-    placed_at: datetime = Field(default=datetime.now(UTC))
+    placed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/ctenex/domain/order_book/trade/model.py
+++ b/ctenex/domain/order_book/trade/model.py
@@ -13,7 +13,7 @@ class Trade(BaseDomainModel):
     sell_order_id: UUID
     price: Decimal
     quantity: Decimal
-    generated_at: datetime = Field(default=datetime.now(UTC))
+    generated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
     model_config = ConfigDict(
         json_schema_extra={

--- a/tests/ctenex/api/v1/controllers/test_exchange.py
+++ b/tests/ctenex/api/v1/controllers/test_exchange.py
@@ -270,8 +270,8 @@ class TestContractsController:
         assert response.json()[0]["location"] == "GB"
         assert response.json()[0]["contract_size"] == "1.00"
         assert response.json()[0]["tick_size"] == "0.01"
-        assert response.json()[0]["start_date"] == "2025-03-01T00:00:00Z"
-        assert response.json()[0]["end_date"] == "2025-03-02T00:00:00Z"
+        assert response.json()[0]["start_date"] == "2025-03-01T00:00:00"
+        assert response.json()[0]["end_date"] == "2025-03-02T00:00:00"
 
     async def test_get_supported_contracts_empty(
         self,


### PR DESCRIPTION
Changes in this MR enable the following filters on the `GET /orders` endpoint:

- `placed_at_or_after`
- `placed_before`

A combination of both is also possible. The idea is to use this new feature in the alpha bot implementation.

Related issue #26
